### PR TITLE
DICT-0004 Available languages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,9 @@ android {
     buildFeatures {
         viewBinding = true
     }
+    sourceSets {
+        test.java.srcDirs += ["${project(':core').projectDir}/src/test/java"]
+    }
 }
 
 dependencies {
@@ -43,6 +46,7 @@ dependencies {
 
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.constraintlayoutVersion"
     testImplementation "junit:junit:$rootProject.junitTest"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.kotlinxCoroutinesTest"
     androidTestImplementation "androidx.test.ext:junit:$rootProject.extJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoCoreVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$rootProject.lifeCycleVersion"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class ru.easycode.words504.core.LanguageCache
+-keep class ru.easycode.words504.core.LanguageCache {*;}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class ru.easycode.words504.core.LanguageCache

--- a/app/src/main/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSource.kt
+++ b/app/src/main/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSource.kt
@@ -1,0 +1,24 @@
+package ru.easycode.words504.data.cache.languages
+
+import ru.easycode.words504.core.LanguageCache
+import ru.easycode.words504.data.cache.storage.ObjectStorage
+
+interface LanguagesCacheDataSource {
+
+    interface Read : ru.easycode.words504.core.Read<List<LanguageCache>>
+    interface Save : ru.easycode.words504.core.Save<List<LanguageCache>>
+    interface Mutable : Read, Save
+
+    class Base(
+        private val objectStorage: ObjectStorage,
+        private val languagesKey: String = "LanguagesKey",
+    ) : LanguagesCacheDataSource, Mutable {
+
+        override fun read(): List<LanguageCache> {
+            val defaultLanguages = emptyList<LanguageCache>()
+            return objectStorage.read(languagesKey, defaultLanguages)
+        }
+
+        override fun save(data: List<LanguageCache>) = objectStorage.save(languagesKey, data)
+    }
+}

--- a/app/src/main/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSource.kt
+++ b/app/src/main/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSource.kt
@@ -11,7 +11,7 @@ interface LanguagesCacheDataSource {
 
     class Base(
         private val objectStorage: ObjectStorage,
-        private val languagesKey: String = "LanguagesKey",
+        private val languagesKey: String = "LanguagesKey"
     ) : LanguagesCacheDataSource, Mutable {
 
         override fun read(): List<LanguageCache> {

--- a/app/src/test/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSourceTest.kt
+++ b/app/src/test/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSourceTest.kt
@@ -19,9 +19,11 @@ class LanguagesCacheDataSourceTest : BaseTest() {
 
     @Test
     fun `test save and read not empty`() {
-        cacheDataSource.save(listOf(
-            LanguageCache.Base("ru", "russian"),
-            LanguageCache.Base("ch", "chinese"))
+        cacheDataSource.save(
+            listOf(
+                LanguageCache.Base("ru", "russian"),
+                LanguageCache.Base("ch", "chinese")
+            )
         )
         val expected = listOf<LanguageCache>(
             LanguageCache.Base("ru", "russian"),

--- a/app/src/test/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSourceTest.kt
+++ b/app/src/test/java/ru/easycode/words504/data/cache/languages/LanguagesCacheDataSourceTest.kt
@@ -1,0 +1,34 @@
+package ru.easycode.words504.data.cache.languages
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import ru.easycode.words504.BaseTest
+import ru.easycode.words504.core.LanguageCache
+
+class LanguagesCacheDataSourceTest : BaseTest() {
+
+    private val cacheDataSource = LanguagesCacheDataSource.Base(FakeObjectStorage())
+
+    @Test
+    fun `test read empty`() = runBlocking {
+        val expected = emptyList<LanguageCache>()
+        val actual = cacheDataSource.read()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `test save and read not empty`() {
+        cacheDataSource.save(listOf(
+            LanguageCache.Base("ru", "russian"),
+            LanguageCache.Base("ch", "chinese"))
+        )
+        val expected = listOf<LanguageCache>(
+            LanguageCache.Base("ru", "russian"),
+            LanguageCache.Base("ch", "chinese")
+        )
+
+        val actual = cacheDataSource.read()
+        assertEquals(expected, actual)
+    }
+}

--- a/core/src/main/java/ru/easycode/words504/core/LanguageCache.kt
+++ b/core/src/main/java/ru/easycode/words504/core/LanguageCache.kt
@@ -1,7 +1,7 @@
 package ru.easycode.words504.core
 
 interface LanguageCache : Empty {
-    class Base(private val key: String, private val name: String) : LanguageCache {
+    data class Base(private val key: String, private val name: String) : LanguageCache {
         override fun isEmpty() = key.isEmpty() || name.isEmpty()
     }
 }


### PR DESCRIPTION
В апп модуль добавлена кэш дата сорс для хранения списка доступных языков, в апп так как считаю это не относится к кор модулю. Для тестов понадобился BaseTest, который находится в кор модуле, что бы получить к нему доступ, в грэдл прописала  
   sourceSets {
        test.java.srcDirs += ["${project(':core').projectDir}/src/test/java"]
    }
Что бы в BaseTest не было ошибок компиляции пришлось добавить
 testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.kotlinxCoroutinesTest", получился дубликат зависимостей в сор модуле и в апп, но без этого не работает
