### PR TITLE
SIGN-0001 Sign-In Intergration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$rootProject.extJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoCoreVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$rootProject.lifeCycleVersion"
+    implementation "com.google.android.gms:play-services-auth:$rootProject.playServicesVersion"
 }
 
 def getDeeplApiKey() {

--- a/app/src/main/java/ru/easycode/words504/languages/data/cloud/SignInDataSource.kt
+++ b/app/src/main/java/ru/easycode/words504/languages/data/cloud/SignInDataSource.kt
@@ -1,0 +1,24 @@
+package ru.easycode.words504.languages.data.cloud
+
+import android.content.Context
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import ru.easycode.words504.domain.HandleError
+
+interface SignInDataSource {
+
+    suspend fun checkSignIn(): GoogleSignInAccount
+
+    class Base(
+        private val context: Context,
+        private val errorHandler: HandleError<Exception, Throwable>
+    ) : SignInDataSource {
+        override suspend fun checkSignIn(): GoogleSignInAccount {
+            try {
+                return GoogleSignIn.getLastSignedInAccount(context)!!
+            } catch (e: Exception) {
+                throw errorHandler.handle(e)
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,4 +23,5 @@ ext {
     constraintlayoutVersion = '2.1.4'
     extJunitVersion = '1.1.5'
     espressoCoreVersion = '3.5.1'
+    playServicesVersion = '20.4.1'
 }


### PR DESCRIPTION
У Гугловской аутентофикации для проверки есть метод GoogleSignIn.getLastSignedInAccount(context) который требует в себя контекст и возвращает аккаунт, если пользователь залогинен, если пользователь вышел, то вернется нулл, соответственно мы пробрасываем эксепшн, если пришел нулл, либо же возвращаем аккаунт, который был авторизован.

Если нам не нужен аккаунт, то можно прост прокидывать эксепшн - пока не понятно как лучше сделать